### PR TITLE
Add --json output option to dfm, rs41 and rs92 demodulators.

### DIFF
--- a/demod/dfm09dm_dft.c
+++ b/demod/dfm09dm_dft.c
@@ -47,7 +47,7 @@ gpx_t gpx;
 char dat_str[9][13+1];
 
 // Buffer to store sonde ID
-char sonde_id[] = "DFMxx-xxxxxx";
+char sonde_id[] = "DFMxx-xxxxxxxx";
 
 int option_verbose = 0,  // ausfuehrliche Anzeige
     option_raw = 0,      // rohe Frames

--- a/demod/dfm09dm_dft.c
+++ b/demod/dfm09dm_dft.c
@@ -46,6 +46,8 @@ gpx_t gpx;
 
 char dat_str[9][13+1];
 
+// Buffer to store sonde ID
+char sonde_id[] = "DFMxx-xxxxxx";
 
 int option_verbose = 0,  // ausfuehrliche Anzeige
     option_raw = 0,      // rohe Frames
@@ -53,6 +55,7 @@ int option_verbose = 0,  // ausfuehrliche Anzeige
     option_ecc = 0,
     option_ptu = 0,
     option_ths = 0,
+    option_json = 0,    // JSON blob output (for auto_rx)
     wavloaded = 0;
 int wav_channel = 0;     // audio channel: left
 
@@ -563,25 +566,37 @@ void print_gpx() {
               {
                   if ((gpx.sonde_typ & 0xF) == 6) { // DFM-06
                       printf(" (ID6:%06X) ", gpx.SN6);
+                      sprintf(sonde_id, "DFM06-%06X", gpx.SN6);
                   }
                   if ((gpx.sonde_typ & 0xF) == 0xA) { // DFM-09
                       printf(" (ID9:%06u) ", gpx.SN);
+                      sprintf(sonde_id, "DFM09-%06u", gpx.SN);
                   }
                   if ((gpx.sonde_typ & 0xF) == 0xC || // DFM-17?
                       (gpx.sonde_typ & 0xF) == 0xD ) {
                       printf(" (ID-%1X:%06u) ", gpx.sonde_typ & 0xF, gpx.SN);
+                      sprintf(sonde_id, "DFM17-%06u", gpx.SN);
                   }
                   gpx.sonde_typ ^= RSNbit;
               }
               if (gpx.sonde_typ & PSNbit) {
                   if ((gpx.sonde_typ & 0xF) == 0x7) { // PS-15?
                       printf(" (ID15:%06u) ", gpx.SN);
+                      sprintf(sonde_id, "DFM15-%06u", gpx.SN);
                   }
                   gpx.sonde_typ ^= PSNbit;
               }
           }
       }
       printf("\n");
+
+      if (option_json)
+      {
+          // Print JSON blob
+          // Get temperature
+          float t = get_Temp(gpx.meas24);
+          printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"temp\":%.1f }\n",  gpx.frnr, sonde_id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.horiV, gpx.dir, gpx.vertV, t );
+      }
 
   }
 }
@@ -711,6 +726,7 @@ int main(int argc, char **argv) {
             fprintf(stderr, "       -i, --invert\n");
             fprintf(stderr, "       --ecc        (Hamming ECC)\n");
             fprintf(stderr, "       --ths <x>    (peak threshold; default=%.1f)\n", thres);
+            fprintf(stderr, "       --json       (JSON output)\n");
             return 0;
         }
         else if ( (strcmp(*argv, "-v") == 0) || (strcmp(*argv, "--verbose") == 0) ) {
@@ -727,6 +743,7 @@ int main(int argc, char **argv) {
             option_inv = 0x1;
         }
         else if ( (strcmp(*argv, "--ecc") == 0) ) { option_ecc = 1; }
+        else if ( (strcmp(*argv, "--json") == 0) ) { option_json = 1; }
         else if ( (strcmp(*argv, "--ptu") == 0) ) { option_ptu = 1;  ptu_out = 1; }
         else if ( (strcmp(*argv, "--ch2") == 0) ) { wav_channel = 1; }  // right channel (default: 0=left)
         else if ( (strcmp(*argv, "--ths") == 0) ) {

--- a/demod/rs41dm_dft.c
+++ b/demod/rs41dm_dft.c
@@ -69,6 +69,7 @@ int option_verbose = 0,  // ausfuehrliche Anzeige
     option_sat = 0,      // GPS sat data
     option_ptu = 0,
     option_ths = 0,
+    option_json = 0,     // JSON output (auto_rx)
     wavloaded = 0;
 int wav_channel = 0;     // audio channel: left
 
@@ -1037,6 +1038,17 @@ int print_position(int ec) {
                 //fprintf(stdout, "  (%.1f %.1f %.1f) ", gpx.vN, gpx.vE, gpx.vU);
                 fprintf(stdout,"  vH: %4.1f  D: %5.1f°  vV: %3.1f ", gpx.vH, gpx.vD, gpx.vU);
             }
+
+            if (option_json){
+                // Print JSON output required by auto_rx.
+                if (!err1 && !err2 && !err3){
+                    if (option_ptu && !err0 && gpx.T > -273.0) {
+                        printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"temp\":%.1f }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU, gpx.T );
+                    } else {
+                        printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU );
+                    }
+                }
+            }
         }
         if (option_ptu && !err0) {
             if (gpx.T > -273.0) printf("  T=%.1fC ", gpx.T);
@@ -1192,6 +1204,7 @@ int main(int argc, char *argv[]) {
             fprintf(stderr, "       --ecc        (Reed-Solomon)\n");
             fprintf(stderr, "       --std        (std framelen)\n");
             fprintf(stderr, "       --ths <x>    (peak threshold; default=%.1f)\n", thres);
+            fprintf(stderr, "       --json       (JSON output)\n");
             return 0;
         }
         else if ( (strcmp(*argv, "-v") == 0) || (strcmp(*argv, "--verbose") == 0) ) {
@@ -1214,6 +1227,7 @@ int main(int argc, char *argv[]) {
         else if   (strcmp(*argv, "--std2") == 0) { frmlen = 518; }  // NDATA_LEN+XDATA_LEN
         else if   (strcmp(*argv, "--sat") == 0) { option_sat = 1; }
         else if   (strcmp(*argv, "--ptu") == 0) { option_ptu = 1; }
+        else if   (strcmp(*argv, "--json") == 0) { option_json = 1; }
         else if   (strcmp(*argv, "--ch2") == 0) { wav_channel = 1; }  // right channel (default: 0=left)
         else if   (strcmp(*argv, "--ths") == 0) {
             ++argv;

--- a/demod/rs92dm_dft.c
+++ b/demod/rs92dm_dft.c
@@ -79,6 +79,7 @@ int option_verbose = 0,  // ausfuehrliche Anzeige
     option_aux = 0,      // Aux/Ozon
     option_der = 0,      // linErr
     option_ths = 0,
+    option_json = 0,     // JSON output (auto_rx)
     rawin = 0;
 int wav_channel = 0;     // audio channel: left
 double dop_limit = 9.9;
@@ -1144,6 +1145,18 @@ int print_position() {  // GPS-Hoehe ueber Ellipsoid
             }
         }
 
+        if (option_json)
+        {
+            // Print out telemetry data as JSON, even if we don't have a valid GPS lock.
+            if (!err1 && !err2){
+                if (gpx.aux[0] != 0 || gpx.aux[1] != 0 || gpx.aux[2] != 0 || gpx.aux[3] != 0) {
+                    printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"aux\": \"%04x%04x%04x%04x\"}\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU , gpx.aux[0], gpx.aux[1], gpx.aux[2], gpx.aux[3]);
+                } else {
+                    printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU );
+                }
+            }
+        }
+
         get_Cal();
 
         if (option_vergps == 8 /*||  option_vergps == 2*/)
@@ -1255,6 +1268,7 @@ int main(int argc, char *argv[]) {
             fprintf(stderr, "       --crc        (CRC check GPS)\n");
             fprintf(stderr, "       --ecc        (Reed-Solomon)\n");
             fprintf(stderr, "       --ths <x>    (peak threshold; default=%.1f)\n", thres);
+            fprintf(stderr, "       --json       (JSON output)\n");
             return 0;
         }
         else if ( (strcmp(*argv, "--vel") == 0) ) {
@@ -1328,6 +1342,7 @@ int main(int argc, char *argv[]) {
         else if (strcmp(*argv, "-g2") == 0) { option_vergps = 2; }  //  verbose2 GPS (bancroft)
         else if (strcmp(*argv, "-gg") == 0) { option_vergps = 8; }  // vverbose GPS
         else if (strcmp(*argv, "--ecc") == 0) { option_ecc = 1; }
+        else if (strcmp(*argv, "--json") == 0) { option_json = 1; } // JSON output (for auto_rx)
         else if (strcmp(*argv, "--ch2") == 0) { wav_channel = 1; }  // right channel (default: 0=left)
         else if (strcmp(*argv, "--ths") == 0) {
             ++argv;


### PR DESCRIPTION
I figured it was about time I submitted a PR for the main changes I've made to the various demodulator code, that is - adding in JSON output for easier parsing of the decoded telemetry!

This adds the --json option to the DFM09, RS92, and RS41 demodulators in the demod directory.