### PR TITLE
pos2nmea: Enforce line buffering

### DIFF
--- a/tools/pos2nmea.pl
+++ b/tools/pos2nmea.pl
@@ -51,6 +51,8 @@ else {
 
 my $geoid = 50.0;  ## GPS ueber Ellipsoid; Geoid-Hoehe in Europa ca 40-50m
 
+$| = 1;  ## line buffering erzwingen
+
 while ($line = <$fpi>) {
 
     print STDERR $line; ## entweder: alle Zeilen ausgeben


### PR DESCRIPTION
When connected to stdout, perl uses line buffering. If not connected to stdout (e.g. from a pipe) it defaults to block buffering. This causes a long delay and decoding issues when using the NMEA output in other tools.

With this change always use line buffering so that NMEA messages are flushed immediately.

Tested with NMEAoIP and GPSD:

```
<decoder> | pos2nmea.pl | socat - tcp-l:4444,reuseaddr,fork
<decoder> | pos2nmea.pl | gpsd -Nnrb /dev/stdin
```

Or with the test data in the repository:

```
ffmpeg -re -i rs41/wav/20140717_402MHz.wav -f wav - | ./rs41mod -i | pos2nmea.pl | socat - tcp-l:4444,reuseaddr,fork
```