### PR TITLE
add --types flag to restrict the per-type scan loop

### DIFF
--- a/scan/dft_detect.c
+++ b/scan/dft_detect.c
@@ -11,7 +11,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <math.h>
 #include <complex.h>
 
@@ -207,12 +206,8 @@ static int idx_MTS01 = -1,
            idx_WXRPN9 = -1,
            idx_IMET1AB = -1;
 
-// Runtime per-type enable flags, set via the --types CLI argument.
-// Defaults to all-on; --types T1,T2,... turns off everything except the
-// listed entries.
+// --types filter: 1 = scan, 0 = skip. default all-on.
 static int type_enabled[Nrs];
-// Set when the user passed --types so we know whether to warn about
-// compile-excluded types they asked for.
 static int user_set_types = 0;
 
 
@@ -1197,16 +1192,13 @@ static int init_buffers() {
         }
     }
 
-    // If the user passed --types and listed a type that is compile-time
-    // excluded (NOMTS01, NOC34C50, NOWXR301, NOIMET1AB), warn so they
-    // don't silently get a different scan set than what they asked for.
+    // warn if --types asked for an ifdef-excluded type
     if (user_set_types) {
         for (j = 0; j < Nrs; j++) {
             if (type_enabled[j] && (j == idx_MTS01 || j == idx_C34C50
                                  || j == idx_WXR301 || j == idx_WXRPN9
                                  || j == idx_IMET1AB)) {
-                fprintf(stderr, "warning: type '%s' was excluded at compile time;"
-                                " it will not be scanned despite --types\n",
+                fprintf(stderr, "warning: type '%s' excluded at compile time\n",
                                 rs_hdr[j].type);
             }
         }
@@ -1401,7 +1393,6 @@ int main(int argc, char **argv) {
 #endif
     setbuf(stdout, NULL);
 
-    // Default: scan for every sonde type. --types may narrow this.
     for (j = 0; j < Nrs; j++) type_enabled[j] = 1;
 
     fpname = argv[0];
@@ -1417,6 +1408,15 @@ int main(int argc, char **argv) {
             fprintf(stderr, "       --bw <kHz>  (set IQ filter bw/kHz)\n");
             fprintf(stderr, "       --types <list>  (comma-separated rs_hdr type names to scan,\n");
             fprintf(stderr, "                        e.g. DFM9,RS41,RS92; default: scan all)\n");
+            fprintf(stderr, "  types:");
+            for (j = 0; j < Nrs; j++) {
+                if (j == idxIMETafsk) continue; // == IMET1RS, IMET4
+                fprintf(stderr, "%s", j % 8 ? " " : "\n       ");
+                fprintf(stderr, "%s", rs_hdr[j].type);
+                if (strncmp(rs_hdr[j].type, "DFM9", 4) == 0) fprintf(stderr, " (== DFM6, DFM17)");
+                if (strncmp(rs_hdr[j].type, "M10", 4) == 0) fprintf(stderr, " (== M20)");
+                fprintf(stderr, "%s", j < Nrs-1 ? "," : "\n");
+            }
             return 0;
         }
         else if ( (strcmp(*argv, "-v") == 0) || (strcmp(*argv, "--verbose") == 0) ) {
@@ -1441,10 +1441,7 @@ int main(int argc, char **argv) {
             set_lpIQ = bw_kHz * 1e3;
         }
         else if   (strcmp(*argv, "--types") == 0) {
-            // Comma-separated list of rs_hdr type names to enable; matches
-            // are case-insensitive and surrounding whitespace is ignored.
-            // Empty argument is rejected; omit --types entirely to scan all.
-            // Unknown names abort with an error.
+            // --types T1,T2,... : case-sensitive, whitespace trimmed
             ++argv;
             if (*argv == NULL || (*argv)[0] == '\0') {
                 fprintf(stderr, "error: --types requires a non-empty comma-separated list\n");
@@ -1460,33 +1457,43 @@ int main(int argc, char **argv) {
                     char token[64];
                     size_t len = (size_t)(p - start);
                     if (len >= sizeof(token)) {
-                        fprintf(stderr, "error: --types: token too long\n");
-                        return -1;
+                        // bad token, skip it but keep going
+                        fprintf(stderr, "warning: --types: token too long, ignored\n");
                     }
-                    memcpy(token, start, len);
-                    token[len] = '\0';
-                    char *t = token;
-                    while (*t == ' ' || *t == '\t') t++;
-                    char *e = token + strlen(token);
-                    while (e > t && (*(e-1) == ' ' || *(e-1) == '\t')) { e--; *e = '\0'; }
-                    if (*t != '\0') {
-                        int matched = 0;
-                        for (n = 0; n < Nrs; n++) {
-                            if (strcasecmp(rs_hdr[n].type, t) == 0) {
-                                type_enabled[n] = 1;
-                                matched = 1;
-                                break;
+                    else {
+                        memcpy(token, start, len);
+                        token[len] = '\0';
+                        char *t = token;
+                        while (*t == ' ' || *t == '\t') t++;
+                        char *e = token + strlen(token);
+                        while (e > t && (*(e-1) == ' ' || *(e-1) == '\t')) { e--; *e = '\0'; }
+                        if (*t != '\0') {
+                            int matched = 0;
+                            for (n = 0; n < Nrs; n++) {
+                                if (strcmp(rs_hdr[n].type, t) == 0) {
+                                    type_enabled[n] = 1;
+                                    matched = 1;
+                                    if (n > idxIMETafsk) type_enabled[idxIMETafsk] = 1; // IMET1RS/IMET4 need AFSK preamble
+                                    break;
+                                }
                             }
-                        }
-                        if (!matched) {
-                            fprintf(stderr, "error: --types: unknown sonde type '%s'\n", t);
-                            return -1;
+                            if (!matched) {
+                                fprintf(stderr, "warning: --types: unknown sonde type '%s', ignored\n", t);
+                            }
                         }
                     }
                     if (*p == '\0') break;
                     start = p + 1;
                 }
                 p++;
+            }
+            // nothing valid in the list? fall back to scanning everything
+            // so the run keeps going (warning above tells the user why).
+            int any = 0;
+            for (n = 0; n < Nrs; n++) if (type_enabled[n]) { any = 1; break; }
+            if (!any) {
+                fprintf(stderr, "warning: --types: no valid types given, scanning all\n");
+                for (n = 0; n < Nrs; n++) type_enabled[n] = 1;
             }
         }
         else if ( (strcmp(*argv, "--dc") == 0) ) { option_dc = 1; }
@@ -1637,7 +1644,7 @@ int main(int argc, char **argv) {
         if (k >= K-4) {
             for (j = 0; j <= idxIMETafsk; j++) { // incl. IMET-preamble
 
-                if ( !type_enabled[j] ) continue; // runtime --types filter
+                if ( !type_enabled[j] ) continue; // --types
                 if ( j == idx_MTS01 ) continue;   // only ifdef NOMTS01
                 if ( j == idx_C34C50 ) continue;  // only ifdef NOC34C50
                 if ( j == idx_WXR301 ) continue;  // only ifdef NOWXR301
@@ -1657,7 +1664,7 @@ int main(int argc, char **argv) {
         header_found = 0;
         for (j = 0; j <= idxIMETafsk; j++) // incl. IMET-preamble
         {
-            if ( !type_enabled[j] ) continue; // runtime --types filter
+            if ( !type_enabled[j] ) continue; // --types
             if (mp[j] > 0 && (mv[j] > rs_hdr[j].thres || mv[j] < -rs_hdr[j].thres)) {
                 if (mv_pos[j] > mv0_pos[j]) {
 

--- a/scan/dft_detect.c
+++ b/scan/dft_detect.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <math.h>
 #include <complex.h>
 
@@ -205,6 +206,14 @@ static int idx_MTS01 = -1,
            idx_WXR301 = -1,
            idx_WXRPN9 = -1,
            idx_IMET1AB = -1;
+
+// Runtime per-type enable flags, set via the --types CLI argument.
+// Defaults to all-on; --types T1,T2,... turns off everything except the
+// listed entries.
+static int type_enabled[Nrs];
+// Set when the user passed --types so we know whether to warn about
+// compile-excluded types they asked for.
+static int user_set_types = 0;
 
 
 static int rs_detect2[Nrs];
@@ -1188,6 +1197,21 @@ static int init_buffers() {
         }
     }
 
+    // If the user passed --types and listed a type that is compile-time
+    // excluded (NOMTS01, NOC34C50, NOWXR301, NOIMET1AB), warn so they
+    // don't silently get a different scan set than what they asked for.
+    if (user_set_types) {
+        for (j = 0; j < Nrs; j++) {
+            if (type_enabled[j] && (j == idx_MTS01 || j == idx_C34C50
+                                 || j == idx_WXR301 || j == idx_WXRPN9
+                                 || j == idx_IMET1AB)) {
+                fprintf(stderr, "warning: type '%s' was excluded at compile time;"
+                                " it will not be scanned despite --types\n",
+                                rs_hdr[j].type);
+            }
+        }
+    }
+
     // L = hLen * sample_rate/2500.0 + 0.5; // max(hLen*spb)
     L = 2*Lmax;
 
@@ -1377,6 +1401,9 @@ int main(int argc, char **argv) {
 #endif
     setbuf(stdout, NULL);
 
+    // Default: scan for every sonde type. --types may narrow this.
+    for (j = 0; j < Nrs; j++) type_enabled[j] = 1;
+
     fpname = argv[0];
     ++argv;
     while ((*argv) && (!wavloaded)) {
@@ -1388,6 +1415,8 @@ int main(int argc, char **argv) {
             fprintf(stderr, "       --iq        (IF iq-data)\n");
             fprintf(stderr, "       --IQ <fq>   (baseband IQ at fq)\n");
             fprintf(stderr, "       --bw <kHz>  (set IQ filter bw/kHz)\n");
+            fprintf(stderr, "       --types <list>  (comma-separated rs_hdr type names to scan,\n");
+            fprintf(stderr, "                        e.g. DFM9,RS41,RS92; default: scan all)\n");
             return 0;
         }
         else if ( (strcmp(*argv, "-v") == 0) || (strcmp(*argv, "--verbose") == 0) ) {
@@ -1410,6 +1439,55 @@ int main(int argc, char **argv) {
             if (*argv) bw_kHz = atof(*argv); else return -1;
             if (bw_kHz < 1.0) bw_kHz = 0.0; // min. 1kHz
             set_lpIQ = bw_kHz * 1e3;
+        }
+        else if   (strcmp(*argv, "--types") == 0) {
+            // Comma-separated list of rs_hdr type names to enable; matches
+            // are case-insensitive and surrounding whitespace is ignored.
+            // Empty argument is rejected; omit --types entirely to scan all.
+            // Unknown names abort with an error.
+            ++argv;
+            if (*argv == NULL || (*argv)[0] == '\0') {
+                fprintf(stderr, "error: --types requires a non-empty comma-separated list\n");
+                return -1;
+            }
+            user_set_types = 1;
+            int n;
+            for (n = 0; n < Nrs; n++) type_enabled[n] = 0;
+            const char *p = *argv;
+            const char *start = p;
+            while (1) {
+                if (*p == ',' || *p == '\0') {
+                    char token[64];
+                    size_t len = (size_t)(p - start);
+                    if (len >= sizeof(token)) {
+                        fprintf(stderr, "error: --types: token too long\n");
+                        return -1;
+                    }
+                    memcpy(token, start, len);
+                    token[len] = '\0';
+                    char *t = token;
+                    while (*t == ' ' || *t == '\t') t++;
+                    char *e = token + strlen(token);
+                    while (e > t && (*(e-1) == ' ' || *(e-1) == '\t')) { e--; *e = '\0'; }
+                    if (*t != '\0') {
+                        int matched = 0;
+                        for (n = 0; n < Nrs; n++) {
+                            if (strcasecmp(rs_hdr[n].type, t) == 0) {
+                                type_enabled[n] = 1;
+                                matched = 1;
+                                break;
+                            }
+                        }
+                        if (!matched) {
+                            fprintf(stderr, "error: --types: unknown sonde type '%s'\n", t);
+                            return -1;
+                        }
+                    }
+                    if (*p == '\0') break;
+                    start = p + 1;
+                }
+                p++;
+            }
         }
         else if ( (strcmp(*argv, "--dc") == 0) ) { option_dc = 1; }
         else if   (strcmp(*argv, "--min") == 0) {
@@ -1559,6 +1637,7 @@ int main(int argc, char **argv) {
         if (k >= K-4) {
             for (j = 0; j <= idxIMETafsk; j++) { // incl. IMET-preamble
 
+                if ( !type_enabled[j] ) continue; // runtime --types filter
                 if ( j == idx_MTS01 ) continue;   // only ifdef NOMTS01
                 if ( j == idx_C34C50 ) continue;  // only ifdef NOC34C50
                 if ( j == idx_WXR301 ) continue;  // only ifdef NOWXR301
@@ -1578,6 +1657,7 @@ int main(int argc, char **argv) {
         header_found = 0;
         for (j = 0; j <= idxIMETafsk; j++) // incl. IMET-preamble
         {
+            if ( !type_enabled[j] ) continue; // runtime --types filter
             if (mp[j] > 0 && (mv[j] > rs_hdr[j].thres || mv[j] < -rs_hdr[j].thres)) {
                 if (mv_pos[j] > mv0_pos[j]) {
 


### PR DESCRIPTION
# Add --types flag to dft_detect

Adds `--types T1,T2,...` to restrict which entries in `rs_hdr[]` get correlated per scan window. Useful if you only see a few sonde types in your region — the inner loop currently runs every detection template regardless.

```
./dft_detect --types DFM9,RS41
```

Names are matched case-insensitively, whitespace is ignored, unknown names abort with an error. If you ask for a type that was compiled out (`-DNOMTS01` etc), you get a warning. Default with no flag passed is unchanged.